### PR TITLE
Index feedback

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,13 +1,12 @@
-# Hugging Face Inference Endpoints
+# 🤗 Inference Endpoints
 
+🤗 Inference Endpoints offers a secure production solution to easily deploy any 🤗 Transformers and Sentence-Transformers models from the Hub on dedicated and autoscaling infrastructure managed by Hugging Face.
 
-🤗 Inference Endpoints offers a secure production solution to easily deploy Machine Learning models on dedicated and autoscaling infrastructure managed by Hugging Face. Any transformers and sentence-transformers model hosted on the Hub should work out of the box.
+A Hugging Face Endpoint is built from a [Hugging Face Model Repository](https://huggingface.co/models). When an Endpoint is created, the service creates image artifacts that are either built from the model you select or a custom-provided container image. The image artifacts are completely decoupled from the Hugging Face Hub source repositories to ensure the highest security and reliability levels.
 
-A Hugging Face Endpoint is built from a [Hugging Face Model Repository](https://huggingface.co/models) and has an account-wide globally unique name. During the creation of an Endpoint, the service will create uniquely encapsulated image artifacts that are either built from the model you select, or based on a custom-provided container image. Those image artifacts are completely decoupled from the Hugging Face Hub source repositories, to achieve the highest security and reliability standards.
+🤗 Inference Endpoints support all of the [🤗 Transformers and Sentence-Transformers tasks](/docs/inference-endpoints/supported_tasks) as well as [custom tasks](/docs/inference-endpoints/guides/custom_handler) not supported by 🤗 Transformers yet like speaker diarization and diffusion.
 
-Hugging Face Endpoints support all of the [Transformers and Sentence-Transformers tasks](/docs/inference-endpoints/supported_tasks) and can support [custom tasks such as custom pre- & post-processing](/docs/inference-endpoints/guides/custom_handler).
-
-In addition, Endpoints gives you the option to use a custom container image you manage on an external service, for instance, hosted on [Docker hub](https://hub.docker.com/), [AWS ECR](https://aws.amazon.com/ecr/?nc1=h_ls), [Azure ACR](https://azure.microsoft.com/de-de/services/container-registry/), or [Google GCR](https://cloud.google.com/container-registry?hl=de). 
+In addition, 🤗 Inference Endpoints gives you the option to use a custom container image managed on an external service, for instance, [Docker Hub](https://hub.docker.com/), [AWS ECR](https://aws.amazon.com/ecr/?nc1=h_ls), [Azure ACR](https://azure.microsoft.com/de-de/services/container-registry/), or [Google GCR](https://cloud.google.com/container-registry?hl=de). 
 
 ![creation-flow](https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/creation_flow.png)
 


### PR DESCRIPTION
The main feedback on the `index` is mostly skipping some of the details and cutting straight to the main points. For example, the user doesn't need to know that the endpoint has a unique name.

I think the diagram is awesome, but I wonder if it'd be clearer if the Repository and custom container blocks are moved before the `create endpoint` block? Currently, it feels like:

```
user creates an endpoint >>> pick a model from the Hub or supplies their own custom container >>> build
```

But this seems more accurate since the endpoint isn't actually created until the model is picked or supplied.

```
user picks model from Hub or supplies their own custom container >>> create endpoint >>> build
```