### PR TITLE
Access feedback

### DIFF
--- a/docs/source/guides/access.mdx
+++ b/docs/source/guides/access.mdx
@@ -1,39 +1,40 @@
-# Access the solution
+# Access 🤗 Inference Endpoints
 
+To access the [🤗 Inference Endpoints web application](https://ui.endpoints.huggingface.co/), you need to be a user or an organization with an active plan. There are currently two plans available:
 
-To access the [🤗 Inference Endpoints web application](https://ui.endpoints.huggingface.co/) you need a user or an organization with an active PLAN. Below you will find instructions on how to upgrade an organization to the ["Pay as you go"](https://huggingface.co/pricing) plan.
+- **Pay as you go** based on your hourly compute, and billed monthly. This plan can be as low as $0.06 per CPU core/hr and $0.6 per GPU/hr depending on your needs.
+- **Enterprise** pricing is custom and based on volume commit and annual contracts. In addition, you'll also receive dedicated support, 24/7 SLAs, and uptime guarantees.
 
-If you are not sure if your organization or user has an active plan you can try to access the UI at [https://ui.endpoints.huggingface.co/](https://ui.endpoints.huggingface.co/). If you don't have an active plan you will an "unauthorized" page with similar instructions than below.
+If you are not sure if your organization or user has an active plan you can try to access the [web application](https://ui.endpoints.huggingface.co/). If you don't have an active plan you will see an unauthorized page with similar instructions as shown below.
 
-## Upgrade an organization to the 'Pay as you go' plan
+To add the **Pay as you go** plan to your organization:
 
-Below are instructions on how to add a plan to your Hugging Face Organization to use Inference endpoints.
-
-### 1. Go to the upgrade page
+1. Go to the upgrade page
 
 You can upgrade your organization following here:  https://huggingface.co/subscribe/lab
 
-### 2. Select the organization you want to upgrade and click 'next'.
+2. Select the organization you want to upgrade and click 'next'.
 
+<Tip>
+  
+If you don't see your organization it means you already have a plan!
 
-_Note: If you are not seeing your organization, it means you already have a plan._
-
+</Tip>
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/0_select_org.png" alt="Select organization" />
 
-### 3. Add an email address, which will receive the invoices
+3. Add an email address, which will receive the invoices
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/1_add_email.png" alt="Add Billing Email" />
 
-### 4. Add your credit card information and hit 'subscribe'.
+4. Add your credit card information and hit 'subscribe'.
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/2_add_cc_info.png" alt="Add Credit card information" />
 
-
-### 5. You will be redirected to your organization account and should see a similar view
+5. You will be redirected to your organization account and should see a similar view
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/3_success.png" alt="Overview" />
 
-### 6. Access the solution via UI 
+6. Access the solution via UI 
 
 Now you can access the solution at: [https://ui.endpoints.huggingface.co/](https://ui.endpoints.huggingface.co/) 

--- a/docs/source/guides/access.mdx
+++ b/docs/source/guides/access.mdx
@@ -1,40 +1,16 @@
 # Access 🤗 Inference Endpoints
 
-To access the [🤗 Inference Endpoints web application](https://ui.endpoints.huggingface.co/), you need to be a user or an organization with an active plan. There are currently two plans available:
-
-- **Pay as you go** based on your hourly compute, and billed monthly. This plan can be as low as $0.06 per CPU core/hr and $0.6 per GPU/hr depending on your needs.
-- **Enterprise** pricing is custom and based on volume commit and annual contracts. In addition, you'll also receive dedicated support, 24/7 SLAs, and uptime guarantees.
-
-If you are not sure if your organization or user has an active plan you can try to access the [web application](https://ui.endpoints.huggingface.co/). If you don't have an active plan you will see an unauthorized page with similar instructions as shown below.
-
-To add the **Pay as you go** plan to your organization:
-
-1. Go to the upgrade page
-
-You can upgrade your organization following here:  https://huggingface.co/subscribe/lab
-
-2. Select the organization you want to upgrade and click 'next'.
+To access the [Inference Endpoints web application](https://ui.endpoints.huggingface.co/), you or your organization need to [add a valid payment method](https://huggingface.co/settings/billing) to your Hugging Face account.
 
 <Tip>
   
-If you don't see your organization it means you already have a plan!
-
+You can check your [billing](https://huggingface.co/settings/billing) if you're unsure whether you have an active payment method.
+  
 </Tip>
 
-<img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/0_select_org.png" alt="Select organization" />
+There are two pricing plans:
 
-3. Add an email address, which will receive the invoices
+- Inference Endpoints pricing is based on your hourly compute, and billed monthly. This can be as low as $0.06 per CPU core/hr and $0.6 per GPU/hr depending on your needs. 
+- There is also an [Enterprise](https://huggingface.co/support) plan for Inference Endpoints which offers dedicated support, 24/7 SLAs, and uptime guarantees. Pricing for Enterprise is custom and based on volume commit and annual contracts; [contact us](https://huggingface.co/inference-endpoints/enterprise) for a quote if you're interested!
 
-<img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/1_add_email.png" alt="Add Billing Email" />
-
-4. Add your credit card information and hit 'subscribe'.
-
-<img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/2_add_cc_info.png" alt="Add Credit card information" />
-
-5. You will be redirected to your organization account and should see a similar view
-
-<img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/access_ui/3_success.png" alt="Overview" />
-
-6. Access the solution via UI 
-
-Now you can access the solution at: [https://ui.endpoints.huggingface.co/](https://ui.endpoints.huggingface.co/) 
+After you've added a valid payment method to your account, access the [Inference Endpoints web application](https://ui.endpoints.huggingface.co/) and start deploying! 🥳


### PR DESCRIPTION
I think you can just use a regular numerical list instead of putting them as section headers. Since you want users to follow the steps sequentially, it doesn't make too much sense to let them skip around like that with the right navbar (plus it'll make it look cleaner!). 

I also described the details of the pricing plans since the link to the Pay as you go plan only takes you to the general pricing page, and it doesn't show any details about the actual plan. You can also replace this with a screenshot if you'd like.

Lastly, clicking on this link: https://huggingface.co/subscribe/lab leads to a 404. Do we still have a Lab plan or has that been replaced by a general Pay as you go plan? This part was a little confusing since it seems like you need to have a Lab plan first and then subscribe to the Pay as you go.