### PR TITLE
Custom container image feedback

### DIFF
--- a/docs/source/guides/custom_container.mdx
+++ b/docs/source/guides/custom_container.mdx
@@ -1,14 +1,14 @@
 # Use a custom Container Image
 
 
-Hugging Face Endpoints not only allows you to [customize your inference handler](/docs/inference-endpoints/guides/custom_handler), it also allows you to provide a custom container image. Those can be public images, e.g _tensorflow/serving:2.7.3,_ or private Images hosted on [Docker hub](https://hub.docker.com/), [AWS ECR](https://aws.amazon.com/ecr/?nc1=h_ls), [Azure ACR](https://azure.microsoft.com/de-de/services/container-registry/), or [Google GCR](https://cloud.google.com/container-registry?hl=de). 
+Inference Endpoints not only allows you to [customize your inference handler](/docs/inference-endpoints/guides/custom_handler), but it also allows you to provide a custom container image. Those can be public images like `tensorflow/serving:2.7.3` or private Images hosted on [Docker Hub](https://hub.docker.com/), [AWS ECR](https://aws.amazon.com/ecr/?nc1=h_ls), [Azure ACR](https://azure.microsoft.com/de-de/services/container-registry/), or [Google GCR](https://cloud.google.com/container-registry?hl=de). 
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/custom_container.png" alt="custom container config" />
 
 
-The [creation flow](/docs/inference-endpoints/guides/) of your Image artifacts will stay the same way on how your custom image is used as the base image. This means that Hugging Face Endpoints will create a unique image artifact derived from your provided image including all Model Artifacts. 
+The [creation flow](/docs/inference-endpoints/guides/create_endpoint) of your Image artifacts from a custom image is the same as the base image. This means Inference Endpoints will create a unique image artifact derived from your provided image, including all Model Artifacts. 
 
-The Model Artifacts (weights) are stored under `/repository`. Meaning if you use` tensorflow/serving` as your custom image you have to set model_base_path to /repository. Below is an example:
+The Model Artifacts (weights) are stored under `/repository`. For example, if you use` tensorflow/serving` as your custom image, then you have to set `model_base_path="/repository":
 
 
 ```


### PR DESCRIPTION
> The [creation flow](https://huggingface.co/docs/inference-endpoints/guides/) of your Image artifacts will stay the same way on how your custom image is used as the base image.

I had a little trouble understanding this, so please let me know if I interpreted it correctly. Also, I fixed the link here to point to the create your first endpoint guide.