### PR TITLE
make heading titles shorter

### DIFF
--- a/docs/source/guides/create_endpoint.mdx
+++ b/docs/source/guides/create_endpoint.mdx
@@ -6,7 +6,9 @@ After your first login, you will be directed to the [Endpoint creation page](htt
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/1_repository.png" alt="select repository" />
 
-## 2. Select your Cloud Provider and region. Initially, only AWS will be available as a Cloud Provider with the `us-east-1` and `eu-west-1` regions. We will add Azure soon, and if you need to test Endpoints with other Cloud Providers or regions, please let us know.
+## 2. Select your Cloud Provider and region:
+
+Initially, only AWS will be available as a Cloud Provider with the `us-east-1` and `eu-west-1` regions. We will add Azure soon, and if you need to test Endpoints with other Cloud Providers or regions, please let us know.
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/1_region.png" alt="select region" />
 
@@ -14,14 +16,22 @@ After your first login, you will be directed to the [Endpoint creation page](htt
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/1_security.png" alt="define security" />
 
-## 4. Create your Endpoint by clicking **Create Endpoint**. By default, your Endpoint is created with a medium CPU (2 x 4GB vCPUs with Intel Xeon Ice Lake) The cost estimate assumes the Endpoint will be up for an entire month, and does not take autoscaling into account.
+## 4. Create your Endpoint:
+
+Click **Create Endpoint**.
+ 
+By default, your Endpoint is created with a medium CPU (2 x 4GB vCPUs with Intel Xeon Ice Lake). The cost estimate assumes that the Endpoint will be up for an entire month, and does not take autoscaling into account.
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/1_create_cost.png" alt="create endpoint" />
 
-## 5. Wait for the Endpoint to build, initialize and run which can take between 1 to 5 minutes.
+## 5. Wait for the Endpoint to build, initialize and run: 
+
+This can take between 1 to 5 minutes.
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/overview.png" alt="overview" />
 
-## 6. Test your Endpoint in the overview with the Inference widget 🏁 🎉!
+## 6. Test your Endpoint:
+
+Use the overview with the Inference widget 🏁 🎉!
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/1_inference.png" alt="run inference" />


### PR DESCRIPTION
The long titles make the navigation headers long and a bit hard to read.

The title should provide just a brief summary of the instructions. More details can then be added in the paragraph below.

## After
![Screen Shot 2022-12-23 at 9 48 10 PM](https://user-images.githubusercontent.com/9806858/209418687-81e035d2-686c-4cc4-8ab9-92e36a3ac8b1.png)
![Screen Shot 2022-12-23 at 9 48 17 PM](https://user-images.githubusercontent.com/9806858/209418690-38b4e998-4acc-4ce4-84dd-360cff68b284.png)


# Problem

![Screen Shot 2022-12-23 at 9 43 39 PM](https://user-images.githubusercontent.com/9806858/209418659-dd171209-1c0d-4f2f-9731-02bf29cad811.png)

![Screen Shot 2022-12-23 at 9 45 59 PM](https://user-images.githubusercontent.com/9806858/209418660-70fe5af5-dfc8-4f3b-b6cd-63e92a39a521.png)


 