### PR TITLE
Link to tokens page in account settings

### DIFF
--- a/docs/source/guides/test_endpoint.mdx
+++ b/docs/source/guides/test_endpoint.mdx
@@ -4,7 +4,7 @@ The Endpoint overview provides access to the Inference Widget which can be used 
 
 <img src="https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/2_copy_curl.png" alt="copy curl" />
 
-The cURL command for the request above should look like this. You'll need to provide your user token which can be found in your Hugging Face account settings:
+The cURL command for the request above should look like this. You'll need to provide your user token which can be found in your Hugging Face [account settings](https://huggingface.co/settings/tokens):
 
 ```bash
 curl https://uu149rez6gw9ehej.eu-west-1.aws.endpoints.huggingface.cloud/distilbert-sentiment \


### PR DESCRIPTION
Since more customers will be looking for it now that the e-mail for `api_org` token deprecation is out.