### PR TITLE
fix: remove useless token

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -18,6 +18,5 @@ jobs:
       package_name: inference-endpoints
       additional_args: --not_python_module
     secrets:
-      token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}
 


### PR DESCRIPTION
This token is not used by your action.
Secret is removed from the repository.