### PR TITLE
Fix link in supported_tasks.mdx - This commit fixes #77

### DIFF
--- a/docs/source/supported_tasks.mdx
+++ b/docs/source/supported_tasks.mdx
@@ -1,6 +1,6 @@
 # Supported Transformers & Diffusers Tasks
 
-Inference Endpoints offers out-of-the-box support for Machine Learning tasks from the Transformers, Sentence-Transformers and Diffusers libraries. Below is a table of Hugging Face managed supported tasks for Inference Endpoint. These tasks don't require any form of code or [“custom container”](/docs/inference-endpoints/guides/docs/guides/custom_container) to deploy an Endpoint. 
+Inference Endpoints offers out-of-the-box support for Machine Learning tasks from the Transformers, Sentence-Transformers and Diffusers libraries. Below is a table of Hugging Face managed supported tasks for Inference Endpoint. These tasks don't require any form of code or [“custom container”](/docs/inference-endpoints/guides/custom_container) to deploy an Endpoint. 
 If you want to customize any of the tasks below, or want to write your own custom task, check out the [“Create your own inference handler”](/docs/inference-endpoints/guides/custom_handler) section for more information. 
 
 Most of the tasks below uses the `pipeline` object, and more information about what additional parameters can be sent to the endpoint is available [here](https://huggingface.co/docs/transformers/main_classes/pipelines).


### PR DESCRIPTION
The link is broken because it is `https://huggingface.co/docs/inference-endpoints/guides/docs/guides/custom_container` and the correct link is `https://huggingface.co/docs/inference-endpoints/guides/custom_container`
