### PR TITLE
docs: fix link in tip on Access 🤗 Inference Endpoints page

### DIFF
--- a/docs/source/guides/access.mdx
+++ b/docs/source/guides/access.mdx
@@ -4,7 +4,7 @@ To access the [Inference Endpoints web application](https://ui.endpoints.hugging
 
 <Tip>
   
-You can check your [billing](https://huggingface.co/settings/billing) if you're unsure whether you have an active payment method.
+You can check your <a href="https://huggingface.co/settings/billing">billing</a> if you're unsure whether you have an active payment method.
   
 </Tip>
 


### PR DESCRIPTION
Putting MD inside HTML doesn't work for MDX. Original view I saw:

https://huggingface.co/docs/inference-endpoints/guides/access
![image](https://github.com/user-attachments/assets/1ee9253c-fbd0-4eb4-9001-54a9b4888986)
