### PR TITLE
[GUIDES] separate section for advanced guides

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -28,7 +28,7 @@
   - local: guides/update_endpoint
     title: Update your Endpoint
   - local: guides/advanced
-    title: Advanced Topics
+    title: Advanced Guides
     sections:
     - local: guides/private_link
       title: Create a Private Endpoint with AWS PrivateLink


### PR DESCRIPTION
This PR splits the guides off into an 'Advanced' section , a bit like the spaces docs. My aim here is to create a golden path for the 80% of users. 

## spaces example
![Screenshot 2025-07-04 at 10 53 02](https://github.com/user-attachments/assets/545d2936-401c-4c51-872c-cb83db9e188f)

## current list
![Screenshot 2025-07-04 at 10 51 44](https://github.com/user-attachments/assets/1186800c-1bb7-42c1-a374-031043f12593)
