### PR TITLE
fix: link to configuration

### DIFF
--- a/docs/source/guides/security.mdx
+++ b/docs/source/guides/security.mdx
@@ -32,20 +32,11 @@ You can read more about security at Hugging Face in general in the following lin
   <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/security-soc-1.jpg" alt="soc-1" class="max-w-[300px] w-full" />
 </div>
 
-## Inference Endpoint Security level
+## Inference Endpoint Security Level
 
-We currently offer four ways of securing your Inference Endpoints:
+We currently offer many different ways of securing your Inference Endpoints through the configuration. Please read more about it in the Inference Endpoints
+configuration [section under security](https://huggingface.co/docs/inference-endpoints/main/en/guides/configuration#security-level).
 
-- **Public**: A Public Endpoint is available from the internet, secured with TLS/SSL, and requires no authentication.
-- **HF Restricted**: The Inference Endpoint is available from the Internet, and secured with TLS/SSL. Anyone with a Hugging Face account can access it, using a personal Hugging Face Token generated from their account.
-- **Protected**: A Protected Endpoint is available from the internet, secured with TLS/SSL, and requires a valid Hugging Face token for authentication.
-- **Private**: A Private Endpoint is only available through an intra-region secured AWS or Azure PrivateLink connection. Private Endpoints are not accessible from the internet.
-
-Public, Protected, and HF Restricted Endpoints do not require any additional configuration. For Private Endpoints, you need to provide
-the AWS account ID of the account that should also have access to Inference Endpoints.
-
-![endpoint-types](https://raw.githubusercontent.com/huggingface/hf-endpoints-documentation/main/assets/endpoint_types.png)
-
-## Further information
+## Further Information
 
 You can read the Hugging Face Privacy Policy at: https://huggingface.co/privacy


### PR DESCRIPTION
Use a link instead of having the same thing double