### PR TITLE
chore: bump doc-builder SHA for PR upload workflow

### DIFF
--- a/.github/workflows/doc-pr-upload.yaml
+++ b/.github/workflows/doc-pr-upload.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
     with:
       package_name: inference-endpoints
     secrets:


### PR DESCRIPTION
Switch the PR doc upload flow from the legacy dataset push to the new HF bucket.
