### PR TITLE
ci: bump doc-builder workflow pins and fix doc-build paths filter

### DIFF
--- a/.github/workflows/doc-build.yaml
+++ b/.github/workflows/doc-build.yaml
@@ -7,11 +7,11 @@ on:
     paths:
       - 'docs/source/**'
       - 'assets/**'
-      - '.github/workflows/doc-build.yml'
+      - '.github/workflows/doc-build.yaml'
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421  # main
     with:
       commit_sha: ${{ github.sha }}
       package: hf-endpoints-documentation

--- a/.github/workflows/doc-pr-build.yaml
+++ b/.github/workflows/doc-pr-build.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/doc-pr-upload.yaml
+++ b/.github/workflows/doc-pr-upload.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@b0f9a6e3b6aa912656cbda9f74896eb721d29421  # main
     with:
       package_name: inference-endpoints
     secrets:


### PR DESCRIPTION
## Context

#165 was merged 2 days ago but the [custom_router guide](https://huggingface.co/docs/inference-endpoints/guides/custom_router) never appeared in the published docs. The doc-build run for that merge reported success, but the `hf-doc-build` bucket was not updated: the workflow is pinned to an outdated `doc-builder` commit (`90b4ee2c`, with `build_main_documentation.yml` changed upstream since).

See Slack thread; fix suggested by @coyotte508.

## Changes

- `doc-build.yaml`: bump `build_main_documentation.yml` pin to `b0f9a6e3b6aa912656cbda9f74896eb721d29421` (doc-builder main as of May 19)
- `doc-pr-build.yaml` / `doc-pr-upload.yaml`: same bump for the PR-preview workflows, which were pinned to the same stale commits
- `doc-build.yaml`: fix the `paths` filter, which referenced `doc-build.yml` while the file is named `doc-build.yaml`. Without this fix, merging this PR would not trigger a rebuild; with it, the merge itself triggers the doc build that publishes the pending guides.

## Verification

- `b0f9a6e3` exists on doc-builder `main` (commit "update (#788)", 2026-05-19)
- `compare/90b4ee2c...b0f9a6e3` shows 11 commits touching the three reusable workflows referenced here
- After merge: the doc-build run should update https://huggingface.co/buckets/hf-doc-build/doc/tree/inference-endpoints/main/en/guides and the custom_router guide should appear under Guides